### PR TITLE
doesn't force includes

### DIFF
--- a/templates/default/service.erb
+++ b/templates/default/service.erb
@@ -1,4 +1,7 @@
-<% @conf_lines.each do |_conf_item_name, conf_line| unless conf_line['disabled'] -%>
+<%
+  @conf_lines.each do |_conf_item_name, conf_line|
+    unless conf_line['disabled']
+-%>
 <%= conf_line['interface'] %> <%= conf_line['control_flag'] %> <%= conf_line['name'] %> <%= conf_line['args'] || nil %>
 <%
     end

--- a/templates/default/service.erb
+++ b/templates/default/service.erb
@@ -1,13 +1,11 @@
-<% 
-  @conf_lines.each do |_conf_item_name, conf_line|
-    unless conf_line['disabled']
--%>
+<% @conf_lines.each do |_conf_item_name, conf_line| unless conf_line['disabled'] -%>
 <%= conf_line['interface'] %> <%= conf_line['control_flag'] %> <%= conf_line['name'] %> <%= conf_line['args'] || nil %>
 <%
     end
   end
 -%>
-
+<% if @includes %>
 <% @includes.each do |include_service| -%>
 @include <%= include_service %>
 <% end -%>
+<% end %>


### PR DESCRIPTION
This PR is just changing the template slightly. There are cases where includes shouldn't be forced on users of the cookbook. This will disable that from being a necessity for convergence. 