### PR TITLE
Add priority key for module ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.0.4
+
+* Add `priority` key to order modules within service
+
 ## v1.0.3
 
 * Gracefully handle when no services are defined

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This cookbook _should_ work fine on Red Hat systems, however it has only been te
           'control_flag' => 'required',
           'name' => 'pam_env.so',
           'args' => 'readenv=1',
-          'disabled' => false
+          'disabled' => false,
+          'priority' => 10,
         }
       },
       'includes' => %w(
@@ -37,6 +38,8 @@ This cookbook _should_ work fine on Red Hat systems, however it has only been te
   ```
 
 *NOTE:* `pam_env` in this case is just a placeholder so that we can use a keyed hash instead of an array.  `disabled` is optional but if it is present and set to true, it will prevent the entry from showing up in the PAM service file.
+
+Line ordering within the service can be achieved by setting the `priority` key, lower numbers coming first. If `priority` is unset, then it is considered to be `9999` and will be at the mercy of node attribute ordering.
 
 ## Usage
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@evertrue.com'
 license          'Apache 2.0'
 description      'Installs/Configures pam'
 long_description 'Installs/Configures pam'
-version          '1.0.3'
+version          '1.0.4'
 
 issues_url 'https://github.com/evertrue/pam-cookbook/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/evertrue/pam-cookbook' if respond_to?(:source_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,10 +21,14 @@ Chef::Log.info "Services: #{node['pam_d'].inspect}"
 
 if node['pam_d']['services']
   node['pam_d']['services'].each do |service, conf|
+    main = conf['main'].to_hash.sort_by { |conf_name, attribs|
+      attribs.fetch('priority', 9999)
+    }
+
     template "/etc/pam.d/#{service}" do
       source 'service.erb'
       variables(
-        conf_lines: conf['main'],
+        conf_lines: main,
         includes: conf['includes']
       )
     end


### PR DESCRIPTION
This pull provides a way of forcing the ordering of module lines within a PAM service. It's a simple optional `priority` key to set in the node attribute under services. Lower numbers come first. Entries without the `priority` key will default to `9999`. Entries with the same number will be ordered by how the node attribute enumerator provides them.

Fixes #5 